### PR TITLE
oprava convert_to_roman

### DIFF
--- a/cv3/cv3.py
+++ b/cv3/cv3.py
@@ -54,8 +54,15 @@ class RomanCalculator:
         return False
 
     def convert_to_roman(self, to_convert: str) -> str:
-        return ''.join([self.to_roman_values[int(to_convert[-i] + '0' * (i - 1))]
-                        for i in range(1, len(to_convert) + 1)])[::-1]
+        arabic_number = int(to_convert)
+        roman_number = ''
+        arabic_values_descending = sorted(self.to_roman_values.keys(), reverse=True).__iter__()
+        while arabic_number > 0:
+            max_value_in_input_number = arabic_values_descending.__next__()
+            for _ in range(arabic_number // max_value_in_input_number):
+                roman_number += self.to_roman_values[max_value_in_input_number]
+                arabic_number -= max_value_in_input_number
+        return roman_number
 
     def calculate(self, expression: str) -> str:
         expression = expression.replace(' ', '')

--- a/cv3/cv3.py
+++ b/cv3/cv3.py
@@ -54,15 +54,8 @@ class RomanCalculator:
         return False
 
     def convert_to_roman(self, to_convert: str) -> str:
-        arabic_number = int(to_convert)
-        roman_number = ''
-        arabic_values_descending = sorted(self.to_roman_values.keys(), reverse=True).__iter__()
-        while arabic_number > 0:
-            max_value_in_input_number = arabic_values_descending.__next__()
-            for _ in range(arabic_number // max_value_in_input_number):
-                roman_number += self.to_roman_values[max_value_in_input_number]
-                arabic_number -= max_value_in_input_number
-        return roman_number
+        return ''.join([self.to_roman_values[int(to_convert[-i] + '0' * (i - 1))]
+                        for i in reversed(range(1, len(to_convert) + 1))])
 
     def calculate(self, expression: str) -> str:
         expression = expression.replace(' ', '')

--- a/cv3/cv3_test.py
+++ b/cv3/cv3_test.py
@@ -169,6 +169,14 @@ class MyTestCase(unittest.TestCase):
     def test_54(self):
         self.assertEqual('Cislo mimo', self.c.calculate('MMM + M'))
 
+    def test_55(self):
+        for i in range(1, 4000):
+            roman: str = self.c.convert_to_roman(str(i))
+            self.assertEqual(i, self.c.convert_to_int(roman), "Wrong convert from arabic to roman")
+
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/cv3/cv3_test.py
+++ b/cv3/cv3_test.py
@@ -175,8 +175,5 @@ class MyTestCase(unittest.TestCase):
             self.assertEqual(i, self.c.convert_to_int(roman), "Wrong convert from arabic to roman")
 
 
-
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Ahoj, opravil som convert_to_roman. Nefungovalo to pre velmi vela cisiel, napr. hned pre 4 to davalo 'VI' a podobne. Pridal som tam test, ktory pre vsetky cisla skusi prehodit ich do rimskych a naspat do arabskych.